### PR TITLE
Make Scout optional

### DIFF
--- a/src-php/Config/novapages.php
+++ b/src-php/Config/novapages.php
@@ -1,6 +1,10 @@
 <?php
 
 return [
+    'models' => [
+        'page' => 'Dewsign\NovaPages\Models\Page',
+        // 'page' => 'Dewsign\NovaPages\Models\PageSearchable',
+    ],
     'repeaters' => [],
     'replaceRepeaters' => false,
     'homepageSlug' => 'homepage',

--- a/src-php/Database/factories/PageFactory.php
+++ b/src-php/Database/factories/PageFactory.php
@@ -3,7 +3,7 @@
 use Faker\Generator as Faker;
 use Dewsign\NovaPages\Models\Page;
 
-$factory->define(Page::class, function (Faker $faker) {
+$factory->define(config('novapages.models.page', Page::class), function (Faker $faker) {
     return [
         'active' => $faker->boolean(90),
         'featured' => $faker->boolean(20),

--- a/src-php/Database/seeds/PageSeeder.php
+++ b/src-php/Database/seeds/PageSeeder.php
@@ -17,13 +17,15 @@ class PageSeeder extends Seeder
      */
     public function run()
     {
-        factory(Page::class, 100)->create()->each(function ($page) {
+        $pageClass = config('novapages.models.page', Page::class);
+
+        factory($pageClass, 100)->create()->each(function ($page) {
             $page->repeaters()->saveMany(factory(Repeater::class, rand(0, 5))->create()->each(function ($repeater) {
                 $repeater->type()->associate(factory(AvailableBlocks::random())->create())->save();
             }));
         });
 
-        Page::inRandomOrder()->take(rand(25, 75))->get()->each(function ($page) {
+        app($pageClass)::inRandomOrder()->take(rand(25, 75))->get()->each(function ($page) {
             $page->parent()->associate(Page::inRandomOrder()->where('id', '<>', $page->id)->first());
             $page->save();
         });

--- a/src-php/Facades/Page.php
+++ b/src-php/Facades/Page.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Dewsign\NovaPages\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Page extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'novapages.page';
+    }
+}

--- a/src-php/Http/Controllers/PageController.php
+++ b/src-php/Http/Controllers/PageController.php
@@ -2,7 +2,7 @@
 
 namespace Dewsign\NovaPages\Http\Controllers;
 
-use Dewsign\NovaPages\Models\Page;
+use Dewsign\NovaPages\Facades\Page;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\View;
 use Illuminate\Foundation\Bus\DispatchesJobs;

--- a/src-php/Models/Page.php
+++ b/src-php/Models/Page.php
@@ -13,13 +13,11 @@ use Maxfactor\Support\Model\Traits\WithPrioritisation;
 use Maxfactor\Support\Webpage\Traits\HasMetaAttributes;
 use Maxfactor\Support\Webpage\Traits\MustHaveCanonical;
 use Dewsign\NovaRepeaterBlocks\Traits\HasRepeaterBlocks;
-use Dewsign\NovaPages\IndexConfigurators\PageIndexConfigurator;
 
 class Page extends Model
 {
     use HasSlug;
     use HasParent;
-    use Searchable;
     use CanBeFeatured;
     use HasActiveState;
     use HasMetaAttributes;
@@ -27,45 +25,7 @@ class Page extends Model
     use MustHaveCanonical;
     use WithPrioritisation;
 
-    protected $indexConfigurator = PageIndexConfigurator::class;
-
-    // Mapping for a model fields.
-    protected $mapping = [
-        'properties' => [
-            'text' => [
-                'type' => 'text',
-                'fields' => [
-                    'raw' => [
-                        'type' => 'keyword',
-                    ]
-                ]
-            ],
-        ]
-    ];
-
-    /**
-     * Get the indexable data array for the model.
-     *
-     * @return array
-     */
-    public function toSearchableArray()
-    {
-        $this->repeaters;
-
-        $searchable = $this->toArray();
-
-        $searchable = array_except($searchable, [
-            'active',
-            'browser_title',
-            'h1',
-            'meta_description',
-            'nav_title',
-            'canonical',
-            'parent',
-        ]);
-
-        return $searchable;
-    }
+    protected $table = 'pages';
 
     /**
      * The attributes that are mass assignable.
@@ -132,7 +92,7 @@ class Page extends Model
      * Recursively add parent pages to the breadcrumb seed
      *
      * @param Illuminate\Support\Collection $seed
-     * @param Dewsign\NovaPages\Models\Page $item
+     * @param Dewsign\NovaPages\Facades\Page $item
      * @return Illuminate\Support\Collection
      */
     private function seedParent(&$seed, $item)

--- a/src-php/Models/PageSearchable.php
+++ b/src-php/Models/PageSearchable.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Dewsign\NovaPages\Models;
+
+use ScoutElastic\Searchable;
+use Dewsign\NovaPages\Models\Page as BasePage;
+use Dewsign\NovaPages\IndexConfigurators\PageIndexConfigurator;
+
+class PageSearchable extends BasePage
+{
+    use Searchable;
+
+    protected $indexConfigurator = PageIndexConfigurator::class;
+
+    // Mapping for a model fields.
+    protected $mapping = [
+        'properties' => [
+            'text' => [
+                'type' => 'text',
+                'fields' => [
+                    'raw' => [
+                        'type' => 'keyword',
+                    ]
+                ]
+            ],
+        ]
+    ];
+
+    /**
+     * Get the indexable data array for the model.
+     *
+     * @return array
+     */
+    public function toSearchableArray()
+    {
+        $this->repeaters;
+
+        $searchable = $this->toArray();
+
+        $searchable = array_except($searchable, [
+            'active',
+            'browser_title',
+            'h1',
+            'meta_description',
+            'nav_title',
+            'canonical',
+            'parent',
+        ]);
+
+        return $searchable;
+    }
+}

--- a/src-php/Nova/Page.php
+++ b/src-php/Nova/Page.php
@@ -59,6 +59,13 @@ class Page extends Resource
         return __('Pages');
     }
 
+    public static function newModel()
+    {
+        $model = config('novapages.models.page', static::$model);
+
+        return new $model;
+    }
+
     /**
      * Get the fields displayed by the resource.
      *

--- a/src-php/NovaPages.php
+++ b/src-php/NovaPages.php
@@ -2,7 +2,7 @@
 
 namespace Dewsign\NovaPages;
 
-use Dewsign\NovaPages\Models\Page;
+use Dewsign\NovaPages\Facades\Page;
 use Illuminate\Support\Facades\File;
 
 class NovaPages

--- a/src-php/Providers/AuthServiceProvider.php
+++ b/src-php/Providers/AuthServiceProvider.php
@@ -42,7 +42,5 @@ class AuthServiceProvider extends ServiceProvider
         });
 
         $this->registerPolicies();
-
-        Gate::policy(config('novapages.models.page', Page::class), PagePolicy::class);
     }
 }

--- a/src-php/Providers/AuthServiceProvider.php
+++ b/src-php/Providers/AuthServiceProvider.php
@@ -18,7 +18,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        Page::class => PagePolicy::class,
+        // Page::class => PagePolicy::class,
     ];
 
     /**
@@ -42,5 +42,7 @@ class AuthServiceProvider extends ServiceProvider
         });
 
         $this->registerPolicies();
+
+        Gate::policy(config('novapages.models.page', Page::class), PagePolicy::class);
     }
 }

--- a/src-php/Providers/PackageServiceProvider.php
+++ b/src-php/Providers/PackageServiceProvider.php
@@ -4,7 +4,7 @@ namespace Dewsign\NovaPages\Providers;
 
 use Laravel\Nova\Nova;
 use Illuminate\Routing\Router;
-use Dewsign\NovaPages\Models\Page;
+use Dewsign\NovaPages\Facades\Page;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
@@ -32,6 +32,8 @@ class PackageServiceProvider extends ServiceProvider
         $this->configurePagination();
         $this->loadTranslations();
         $this->bootRoutes();
+
+        $this->app->bind('novapages.page', config('novapages.models.page', 'Dewsign\NovaPages\Models\Page'));
     }
 
     /**

--- a/src-php/Tests/PageTest.php
+++ b/src-php/Tests/PageTest.php
@@ -2,7 +2,7 @@
 
 namespace Dewsign\NovaPages\Tests;
 
-use Dewsign\NovaPages\Models\Page;
+use Dewsign\NovaPages\Facades\Page;
 use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;


### PR DESCRIPTION
Bit of a mare with this one. Basically I tried using a Facade to map the model to the config value. This works great in most places, apart from factories and nova where I had to access the config variables directly. Nova uses a static variable which as a result can't be read from the config so it just defaults to reading the non-searchable model (deffo feels hacky!)