### PR TITLE
Don't allow own resource id as parent

### DIFF
--- a/src-php/Nova/Page.php
+++ b/src-php/Nova/Page.php
@@ -84,7 +84,7 @@ class Page extends Resource
             Number::make('Priority')->sortable()->rules('required', 'integer'),
             TextWithSlug::make('Name')->sortable()->rules('required_if:active,1', 'max:254')->slug('Slug'),
             Slug::make('Slug')->sortable()->rules('required', 'alpha_dash', 'max:254')->hideFromIndex(),
-            BelongsTo::make('Parent', 'parent', self::class)->nullable()->searchable(),
+            BelongsTo::make('Parent', 'parent', self::class)->nullable()->searchable()->rules('not_in:{{resourceId}}'),
             Text::make('Full Path', function () {
                 return $this->full_path;
             })->hideFromIndex(),


### PR DESCRIPTION
This issues has broken sites in the past, let's not allow it any more.

Adding validation to parent 'belongsTo'

I originally wanted to exclude the resource from the select options but couldn't find a nice way of doing this as this situation only applies to 'Update' scenarios.