### PR TITLE
Make homepage only accessible via the root url to fix #18

### DIFF
--- a/src-php/Http/Middleware/RedirectHomepageSlugToRoot.php
+++ b/src-php/Http/Middleware/RedirectHomepageSlugToRoot.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Dewsign\NovaPages\Http\Middleware;
+
+class RedirectHomepageSlugToRoot
+{
+    /**
+     * Ensure the homepage can not be accessed at multiple URLs
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return \Illuminate\Http\Response
+     */
+    public function handle($request, $next)
+    {
+        $homepageSlug = config('novapages.homepageSlug');
+
+        if ($homepageSlug && $request->is($homepageSlug)) {
+            return redirect('/', 301);
+        }
+
+        return $next($request);
+    }
+}

--- a/src-php/Providers/PackageServiceProvider.php
+++ b/src-php/Providers/PackageServiceProvider.php
@@ -13,6 +13,7 @@ use Dewsign\NovaPages\Http\Middleware\ServePages;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Dewsign\NovaPages\Events\NovaPagesProviderRegistered;
+use Dewsign\NovaPages\Http\Middleware\RedirectHomepageSlugToRoot;
 
 class PackageServiceProvider extends ServiceProvider
 {
@@ -31,7 +32,7 @@ class PackageServiceProvider extends ServiceProvider
         $this->registerMorphMaps();
         $this->configurePagination();
         $this->loadTranslations();
-        $this->bootRoutes();
+        $this->bootRoutes($router);
     }
 
     /**
@@ -165,7 +166,7 @@ class PackageServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    private function bootRoutes()
+    private function bootRoutes(Router $router)
     {
         Event::listen(NovaPagesProviderRegistered::class, function () {
             $this->app->register(RouteServiceProvider::class);
@@ -177,5 +178,7 @@ class PackageServiceProvider extends ServiceProvider
 
         $this->app->make(HttpKernel::class)
             ->pushMiddleware(ServePages::class);
+
+        $router->pushMiddlewareToGroup('web', RedirectHomepageSlugToRoot::class);
     }
 }


### PR DESCRIPTION
When the `homepageSlug` is accessed we will now automatically redirect to `/` to avoid the homepage being accessible on multiple URLs.