### PR TITLE
Domain map routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ return [
 
 If you create a page with the `careers` slug, this and any sub-pages will be served on the sub-domain with the base slug removed. E.g. `mydomain.com/careers/vacancies` will become `careers.mydomain.com/vacancies`.
 
-NOTE: The domain name routing is not handled by this package, only the removal of the slug, your application will need to take care of the domain name handling.
+*Important: You will need to ensure that any non-page routes go to the the correct domain name. We recommend always routing to full URLs rather than relative path.*

--- a/src-php/Http/Controllers/PageController.php
+++ b/src-php/Http/Controllers/PageController.php
@@ -4,7 +4,9 @@ namespace Dewsign\NovaPages\Http\Controllers;
 
 use Dewsign\NovaPages\Models\Page;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Redirect;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -13,14 +15,41 @@ class PageController extends Controller
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 
+    /**
+     * The main show route to display pages. This includes domain mapped pages and the homepage.
+     * In general, this method could do with some cleaning up but everything works for now.
+     *
+     * If a domain mapped page is requested on a different domain it will automatically
+     * be redirected to the correct domain name mapped path.
+     *
+     * @param string $domain
+     * @param string $path
+     * @return \Illuminate\View\View
+     */
     public function show(string $domain = null, string $path = null)
     {
         if (!$path) {
             $path = $domain;
+            $domain = null;
         }
 
+        if ($domain && in_array($domain, config('novapages.domainMap'))) {
+            $path = str_replace(config('novapages.homepageSlug'), '', $path);
+            /**
+             * Since we are now mapping to domain names we actually need to reverse
+             * the map in order to lookup the correct page with the full path.
+             */
+            $reverseMappedPath = collect([$domain, $path])->filter()->implode('/');
+        }
+
+        if ($desiredRoute = config('novapages.models.page', Page::class)::isWithinDomainMap($domain, $path)) {
+            if ($desiredRoute !== URL::current()) {
+                return Redirect::away($desiredRoute);
+            }
+        };
+
         $page = app(config('novapages.models.page', Page::class))::withParent()
-            ->whereFullPath($path)
+            ->whereFullPath($reverseMappedPath ?? $path, $excludeMappedDomains = false)
             ->first();
 
         if (!$page) {

--- a/src-php/Nova/Page.php
+++ b/src-php/Nova/Page.php
@@ -86,7 +86,7 @@ class Page extends Resource
             Slug::make('Slug')->sortable()->rules('required', 'alpha_dash', 'max:254')->hideFromIndex(),
             BelongsTo::make('Parent', 'parent', self::class)->nullable()->searchable()->rules('not_in:{{resourceId}}'),
             Text::make('Full Path', function () {
-                return $this->full_path;
+                return $this->mapped_url;
             })->hideFromIndex(),
             config('novapages.images.field')::make('Image')->disk(config('novapages.images.disk', 'public')),
             Textarea::make('Summary'),

--- a/src-php/NovaPages.php
+++ b/src-php/NovaPages.php
@@ -10,7 +10,7 @@ class NovaPages
     public static function sitemap($sitemap)
     {
         app(config('novapages.models.page', Page::class))::active()->get()->map(function ($item) use ($sitemap) {
-            $sitemap->add(url($item->full_path));
+            $sitemap->add(url($item->mapped_url));
         });
     }
 

--- a/src-php/Routes/pages.php
+++ b/src-php/Routes/pages.php
@@ -3,7 +3,7 @@
 $nova_url = ltrim(config('nova.path'), '/');
 
 Route::get('{path?}', 'PageController@show')
-    ->name('show')
+    ->name('pages.show')
     ->where(['path' => '^(?!' . $nova_url  . '|nova-api|nova-vendor).*'])
     ->defaults('domain', '')
     ->defaults('path', config('novapages.homepageSlug', 'homepage'));

--- a/src-php/Routes/web.php
+++ b/src-php/Routes/web.php
@@ -3,7 +3,7 @@
 /**
  * Page Routes. Should be the last route as it doesn't have a root namespace and could take-over other routes
  */
-Route::domain('{domain}.' . config('novapages.rootDomain'))->name('pages.')->group(function () {
+Route::domain('{domain}.' . config('novapages.rootDomain'))->name('domain.')->group(function () {
     include('pages.php');
 });
 


### PR DESCRIPTION
This finishes a buggy implementation of the sub-domain mapping of folders. You can now correctly map any first level page (e.g. `/careers`) to a sub-domain, `careers.mydomain.com` and this package will automatically redirect to the correct full url.

It is a bit of a mess but it all works and also fixes the tests.